### PR TITLE
Check audit log when user rejoins Org

### DIFF
--- a/landing_page_app/main/scripts/github_script.py
+++ b/landing_page_app/main/scripts/github_script.py
@@ -85,3 +85,12 @@ class GithubScript:
         if as_org:
             organisations.append(MOJ_ANALYTICAL_SERVICES)
         return organisations
+
+    def is_user_in_audit_log(self, username: str = "", organisation: str = ""):
+        found_user = False
+        # TODO: change MOJ_TEST_ORG to organisation
+        removed_users = self.github_service.get_removed_users_from_audit_log(MOJ_TEST_ORG)
+        username = username.lower()
+        if username in removed_users:
+            found_user = True
+        return found_user

--- a/landing_page_app/main/scripts/join_github_form.py
+++ b/landing_page_app/main/scripts/join_github_form.py
@@ -1,5 +1,6 @@
 import re
 from wtforms import Form, BooleanField, StringField, validators, ValidationError
+from flask import current_app
 
 
 class InputCheck:
@@ -64,4 +65,11 @@ class JoinGithubForm(Form):
             self.access_moj_org.errors.append("Select an Organisation")
             self.access_as_org.errors.append("Select an Organisation")
             return False
+        return True
+
+    def validate_user_rejoining_org(self, username: str = "", organisations: list[str] = []):
+        for organisation in organisations:
+            if current_app.github_script.is_user_in_audit_log(username, organisation) is False:
+                self.gh_username.errors.append(f"Sorry you have not been part of the {organisation} Organisation in the past 90 days")
+                return False
         return True

--- a/landing_page_app/main/services/github_service.py
+++ b/landing_page_app/main/services/github_service.py
@@ -42,7 +42,7 @@ class GithubService:
             for event in audit_log_data:
                 user = event.get("user")
                 if user:
-                    users.add(user)
+                    users.add(user.lower())
 
             # Check for next page in Pagination
             if response.links.get("next") is not None:

--- a/landing_page_app/main/views.py
+++ b/landing_page_app/main/views.py
@@ -50,16 +50,20 @@ def completed_join_github_form():
                 form.gh_username.data, form.email_address.data, selected_orgs
             )
             if len(non_approved_requests) == 0:
+                # Approved email address. Invite sent to user
                 return redirect("thank-you")
+            # Non approved email address. Slack alert created
             current_app.slack_service.send_add_new_user_to_github_orgs(
                 non_approved_requests
             )
             return redirect("use-slack")
         if form.validate_user_rejoining_org(form.gh_username.data, selected_orgs):
+            # User re-joining. Slack alert created
             current_app.slack_service.send_user_wants_to_rejoin_github_orgs(
                 form.gh_username.data, form.email_address.data, selected_orgs
             )
             return redirect("use-slack-rejoin-org")
+    # Problem in the form
     return render_template(
         "join-github-form.html", form=form, template="join-github-form.html"
     )

--- a/landing_page_app/main/views.py
+++ b/landing_page_app/main/views.py
@@ -55,10 +55,11 @@ def completed_join_github_form():
                 non_approved_requests
             )
             return redirect("use-slack")
-        current_app.slack_service.send_user_wants_to_rejoin_github_orgs(
-            form.gh_username.data, form.email_address.data, selected_orgs
-        )
-        return redirect("use-slack-rejoin-org")
+        if form.validate_user_rejoining_org(form.gh_username.data, selected_orgs):
+            current_app.slack_service.send_user_wants_to_rejoin_github_orgs(
+                form.gh_username.data, form.email_address.data, selected_orgs
+            )
+            return redirect("use-slack-rejoin-org")
     return render_template(
         "join-github-form.html", form=form, template="join-github-form.html"
     )

--- a/landing_page_app/templates/use-slack-rejoin-org.html
+++ b/landing_page_app/templates/use-slack-rejoin-org.html
@@ -7,14 +7,18 @@ Use Slack
 {% block content %}
 <h1 class="govuk-heading-xl">Request Pending</h1>
 
-<h2 class="govuk-heading-m">Thank you but to rejoin the Organisation requires involvement from the Operations-Engineering team.</h2>
+<h2 class="govuk-heading-m">Thank you! Your request to rejoin the Organisation/s has been sent to the Operations-Engineering team.</h2>
 
 <p class="govuk-body">
   A request has been created on the Operations-Engineering team Slack channel <a href="https://mojdt.slack.com/archives/C01BUKJSZD4" class="govuk-link">#ask-operations-engineering</a>.
 </p>
 
 <p class="govuk-body">
-  Please find your request in the Slack channel and we can discuss the request together.
+  Email invites to rejoin the Organisation/s will be sent out soon.
+</p>
+
+<p class="govuk-body">
+  If you need more assistance find your request in the Slack channel.
 </p>
 
 <a href="/home" class="govuk-back-link">Back</a>

--- a/tests/scripts/test_github_script.py
+++ b/tests/scripts/test_github_script.py
@@ -21,6 +21,27 @@ class TestGithubScript(unittest.TestCase):
         self.approved_email_address = "some@justice.gov.uk"
 
     @patch("landing_page_app.main.services.github_service")
+    def test_is_user_in_audit_log_when_no_users_in_audit_log(self, mock_github_service):
+        github_script = GithubScript(mock_github_service)
+        mock_github_service.get_removed_users_from_audit_log.return_value = []
+        found_user = github_script.is_user_in_audit_log(self.test_user, MOJ_TEST_ORG)
+        self.assertEqual(found_user, False)
+
+    @patch("landing_page_app.main.services.github_service")
+    def test_is_user_in_audit_log_when_different_users_in_audit_log(self, mock_github_service):
+        github_script = GithubScript(mock_github_service)
+        mock_github_service.get_removed_users_from_audit_log.return_value = ["some-user1", "some-user2"]
+        found_user = github_script.is_user_in_audit_log(self.test_user, MOJ_TEST_ORG)
+        self.assertEqual(found_user, False)
+
+    @patch("landing_page_app.main.services.github_service")
+    def test_is_user_in_audit_log(self, mock_github_service):
+        github_script = GithubScript(mock_github_service)
+        mock_github_service.get_removed_users_from_audit_log.return_value = [self.test_user]
+        found_user = github_script.is_user_in_audit_log(self.test_user, MOJ_TEST_ORG)
+        self.assertEqual(found_user, True)
+
+    @patch("landing_page_app.main.services.github_service")
     def test_is_email_address_pre_approved_with_as_org_approved_email_addresses(
         self, mock_github_service
     ):

--- a/tests/views/test_views.py
+++ b/tests/views/test_views.py
@@ -227,6 +227,17 @@ class TestCompletedJoinGithubForm(unittest.TestCase):
             "some-username", "some@email.com", [self.org]
         )
 
+    def test_fail_join_github_form_when_user_wants_to_rejoin_org(self):
+        self.app.github_script.get_selected_organisations.return_value = [self.org]
+        self.app.github_script.is_user_in_audit_log.return_value = False
+        # Give the checkbox a value to make it True in the form validator
+        self.form_data["is_user_rejoining_org"] = "some-value"
+        response = self.app.test_client().post(
+            "/join-github-form", data=self.form_data, follow_redirects=True
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.request.path, "/join-github-form")
+
 
 class TestCompletedRateLimit(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
When user ticks the rejoin button on the form this will check the removed user is in the audit log for each Organisation selected in the form. 
If the username is found it will raise a Slack message to manually invite the user to the Org/s.
If the username is not found, an error message is returned to the user via the form. 