### PR TITLE
Add recaptcha to Form

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,4 @@
 export GH_TOKEN=fake
 export SLACK_TOKEN=fake
+export RECAPTCHA_PUBLIC_KEY=fake
+export RECAPTCHA_PRIVATE_KEY=fake

--- a/landing_page_app/__init__.py
+++ b/landing_page_app/__init__.py
@@ -20,7 +20,7 @@ from landing_page_app.main.views import (
 )
 
 
-def create_app(github_script: GithubScript, slack_service: SlackService, rate_limit: bool = True) -> Flask:
+def create_app(github_script: GithubScript, slack_service: SlackService, recaptcha_public_key: str, recaptcha_private_key: str, rate_limit: bool = True) -> Flask:
     logging.basicConfig(
         format="%(asctime)s %(levelname)s in %(module)s: %(message)s",
     )
@@ -44,6 +44,9 @@ def create_app(github_script: GithubScript, slack_service: SlackService, rate_li
     app.logger.setLevel(logging.DEBUG)
     app.config.from_object("landing_page_app.config.development")
     app.logger.info("Running in Development mode.")
+
+    app.config["RECAPTCHA_PUBLIC_KEY"] = recaptcha_public_key
+    app.config["RECAPTCHA_PRIVATE_KEY"] = recaptcha_private_key
 
     app.secret_key = app.config.get("APP_SECRET_KEY")
 

--- a/landing_page_app/main/scripts/join_github_form.py
+++ b/landing_page_app/main/scripts/join_github_form.py
@@ -1,6 +1,7 @@
 import re
 from wtforms import Form, BooleanField, StringField, validators, ValidationError
 from flask import current_app
+from flask_wtf import RecaptchaField
 
 
 class InputCheck:
@@ -17,6 +18,7 @@ class InputCheck:
 
 
 class JoinGithubForm(Form):
+    recaptcha = RecaptchaField("reCaptcha")
     gh_username = StringField(
         "GitHub Username",
         [

--- a/landing_page_app/templates/join-github-form.html
+++ b/landing_page_app/templates/join-github-form.html
@@ -93,6 +93,9 @@ Join GitHub Form
               </div>
             </fieldset>
           </div>
+          <p class="govuk-body">
+            {{ form.recaptcha }}
+          </p>
           <button class="govuk-button" type="submit" data-module="govuk-button">
             Continue
           </button>

--- a/operations_engineering_landing_page.py
+++ b/operations_engineering_landing_page.py
@@ -26,15 +26,32 @@ def get_tokens():
         if not slack_token:
             logging.error("Failed to find a Slack Token")
             sys.exit(1)
-    return github_token, slack_token
+
+    recaptcha_public_key = environ.get("RECAPTCHA_PUBLIC_KEY")
+    if not recaptcha_public_key:
+        # Look for a local .env file
+        recaptcha_public_key = dotenv_values(".env").get("RECAPTCHA_PUBLIC_KEY")
+        if not recaptcha_public_key:
+            logging.error("Failed to find recaptcha public key")
+            sys.exit(1)
+
+    recaptcha_private_key = environ.get("RECAPTCHA_PRIVATE_KEY")
+    if not recaptcha_private_key:
+        # Look for a local .env file
+        recaptcha_private_key = dotenv_values(".env").get("RECAPTCHA_PRIVATE_KEY")
+        if not recaptcha_private_key:
+            logging.error("Failed to find recaptcha private key")
+            sys.exit(1)
+
+    return github_token, slack_token, recaptcha_public_key, recaptcha_private_key
 
 
 def build_app():
-    github_token, slack_token = get_tokens()
+    github_token, slack_token, recaptcha_public_key, recaptcha_private_key = get_tokens()
     github_service = GithubService(github_token)
     github_script = GithubScript(github_service)
     slack_service = SlackService(slack_token)
-    return create_app(github_script, slack_service)
+    return create_app(github_script, slack_service, recaptcha_public_key, recaptcha_private_key)
 
 
 # Gunicorn entry point, return the object without running it

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,5 @@ python-dotenv
 requests
 slack_sdk
 WTForms
+Flask-WTF
 Flask-Limiter

--- a/tests/views/test_views.py
+++ b/tests/views/test_views.py
@@ -19,7 +19,9 @@ class TestViews(unittest.TestCase):
     def setUp(self):
         self.github_script = MagicMock(GithubScript)
         self.slack_service = MagicMock(SlackService)
-        self.app = landing_page_app.create_app(self.github_script, self.slack_service, False)
+        self.recaptcha_public_key = "fake"
+        self.recaptcha_private_key = "fake"
+        self.app = landing_page_app.create_app(self.github_script, self.slack_service, self.recaptcha_public_key, self.recaptcha_private_key, False)
 
     def test_index(self):
         response = self.app.test_client().get("index")
@@ -107,7 +109,9 @@ class TestCompletedJoinGithubForm(unittest.TestCase):
         self.org = "some-org"
         self.github_script = MagicMock(GithubScript)
         self.slack_service = MagicMock(SlackService)
-        self.app = landing_page_app.create_app(self.github_script, self.slack_service, False)
+        self.recaptcha_public_key = "fake"
+        self.recaptcha_private_key = "fake"
+        self.app = landing_page_app.create_app(self.github_script, self.slack_service, self.recaptcha_public_key, self.recaptcha_private_key, False)
 
     def test_join_github_form(self):
         self.app.github_script.get_selected_organisations.return_value = [self.org]
@@ -269,7 +273,9 @@ class TestCompletedRateLimit(unittest.TestCase):
         self.org = "some-org"
         self.github_script = MagicMock(GithubScript)
         self.slack_service = MagicMock(SlackService)
-        self.app = landing_page_app.create_app(self.github_script, self.slack_service, True)
+        self.recaptcha_public_key = "fake"
+        self.recaptcha_private_key = "fake"
+        self.app = landing_page_app.create_app(self.github_script, self.slack_service, self.recaptcha_public_key, self.recaptcha_private_key, True)
 
     def test_rate_limit(self):
         # Send requests until you receive a 429 response


### PR DESCRIPTION
This PR adds recaptcha to the form. This requires setup on a Google account, which provides the public and private keys that need to be added to the AWS secret manager. See the [document](https://docs.google.com/document/d/1LEBL0QJZAHbSYvySUPLLN2R_hGnS4SGVF81ACZO3oQY/edit) for more information